### PR TITLE
Implement undo functionality with toast notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,22 @@
         .dark .modal {
             background-color: rgba(0, 0, 0, 0.7);
         }
+        @keyframes slideUp {
+            from {
+                transform: translateY(100%);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
+        .animate-slide-up {
+            animation: slideUp 0.3s ease-out;
+        }
+        #toast-notification {
+            transition: opacity 0.2s ease-out;
+        }
     </style>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 transition-colors duration-200">


### PR DESCRIPTION
Add undo functionality to actions with toast notifications for user feedback. Users can now revert actions like resetting the week plan or deleting a recipe, enhancing the overall user experience.