### PR TITLE
Update release type to simple in configuration files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          release-type: node
+          release-type: simple
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-publish:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "node",
+      "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "include-v-in-tag": true,


### PR DESCRIPTION
Change the release type from 'node' to 'simple' in the workflow and configuration files to align with the intended release strategy.