### PR TITLE
fix: remove duplicate lines in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,10 @@ services:
 
   backend:
     image: ghcr.io/milkrunner/foodplanner/backend:${VERSION:-latest}
-    image: ghcr.io/milkrunner/foodplanner/backend:${VERSION:-latest}
     container_name: foodplanner-backend
     ports:
       - "3000:3000"
     environment:
-      NODE_ENV: production
       NODE_ENV: production
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       DATABASE_URL: postgresql://foodplanner:${DB_PASSWORD:-foodplanner_secret}@postgres:5432/foodplanner
@@ -38,7 +36,6 @@ services:
     restart: unless-stopped
 
   nginx:
-    image: ghcr.io/milkrunner/foodplanner/frontend:${VERSION:-latest}
     image: ghcr.io/milkrunner/foodplanner/frontend:${VERSION:-latest}
     container_name: foodplanner-nginx
     depends_on:


### PR DESCRIPTION
## Summary
- Remove duplicate `image:` and `NODE_ENV:` lines in docker-compose.yml

## Test plan
- [x] Verify docker-compose.yml is valid YAML
- [ ] Test `docker-compose up -d` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)