### PR TITLE
fix: use --omit=dev instead of deprecated --only=production

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
 # Copy all application files
 COPY . .


### PR DESCRIPTION
## Summary
- Replace deprecated `--only=production` with `--omit=dev` in Dockerfile

## Notes
When merging this PR, please use **Squash and merge** and keep the commit title as:
```
fix: use --omit=dev instead of deprecated --only=production
```

This ensures Release Please can parse the commit correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)