### PR TITLE
fix: correct docker-compose filename in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           mkdir -p release-assets
 
           # Copy only the files needed for deployment
-          cp docker-compose.prod.yml release-assets/docker-compose.yml
+          cp docker-compose.yml release-assets/
           cp .env.example release-assets/
 
           # Create archives


### PR DESCRIPTION
## Summary
- Fix release workflow to use `docker-compose.yml` instead of `docker-compose.prod.yml`

The previous release (v1.3.2) failed because the workflow tried to copy a non-existent file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)