### PR TITLE
fix: remove leaked .env file from repository

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-# Gemini API Key
-# Erhalte deinen kostenlosen API Key hier: https://aistudio.google.com/apikey
-GEMINI_API_KEY="AIzaSyAeM4Pgg9cBX3LV_7x7ln7mxxyRxBNsNyI"


### PR DESCRIPTION
## Summary
- Remove `.env` file that was accidentally committed containing API keys
- The file is already in `.gitignore` so it won't be re-added

## Security Note
The Gemini API key in the leaked `.env` has already been flagged by Google as compromised. A new API key should be generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)