### PR TITLE
Update Dockerfile for streamlined npm installation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,4 @@
 # Backend Dockerfile - Node.js API
-FROM ghcr.io/milkrunner/foodplanner/backend:latest AS deps
-
 FROM node:20-alpine
 
 # Install system dependencies for video processing
@@ -15,8 +13,9 @@ RUN apk add --no-cache \
 # Set working directory
 WORKDIR /app
 
-# Reuse dependencies from the published image to avoid npm during build
-COPY --from=deps /app/node_modules ./node_modules
+# Copy package files and install dependencies
+COPY package*.json ./
+RUN npm ci --only=production
 
 # Copy all application files including custom overrides
 COPY . .


### PR DESCRIPTION
Remove dependency reuse in the Dockerfile to simplify the npm installation process. This change enhances the build efficiency by directly installing dependencies from the package files.