### PR TITLE
fix: ensure CSP headers are applied to all nginx locations

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -10,39 +10,35 @@ http {
         server backend:3000;
     }
 
+    # Security headers as variables (reusable across locations)
+    map $uri $csp_header {
+        default "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://*:* https://*:* ws://*:*; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';";
+    }
+
     server {
         listen 80;
         server_name localhost;
 
-        # Security Headers
-        # Content Security Policy - protects against XSS and injection attacks
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://*:* https://*:* ws://*:*; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+        root /usr/share/nginx/html;
 
-        # Prevent MIME type sniffing
+        # Security Headers (applied globally)
+        add_header Content-Security-Policy $csp_header always;
         add_header X-Content-Type-Options "nosniff" always;
-
-        # Prevent clickjacking
         add_header X-Frame-Options "DENY" always;
-
-        # Control referrer information
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
-        # Permissions Policy (formerly Feature-Policy)
         add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
-
-        # XSS Protection (legacy, but still useful for older browsers)
         add_header X-XSS-Protection "1; mode=block" always;
 
         # Frontend
         location / {
-            root /usr/share/nginx/html;
             index index.html;
             try_files $uri $uri/ /index.html;
         }
 
         # Service Worker - must not be cached
         location = /sw.js {
-            root /usr/share/nginx/html;
+            add_header Content-Security-Policy $csp_header always;
+            add_header X-Content-Type-Options "nosniff" always;
             add_header Cache-Control "no-cache, no-store, must-revalidate";
             add_header Pragma "no-cache";
             add_header Expires "0";
@@ -51,14 +47,16 @@ http {
 
         # PWA Manifest
         location = /manifest.json {
-            root /usr/share/nginx/html;
+            add_header Content-Security-Policy $csp_header always;
+            add_header X-Content-Type-Options "nosniff" always;
             add_header Cache-Control "public, max-age=86400";
             types { application/manifest+json json; }
         }
 
         # PWA Icons
         location /icons/ {
-            root /usr/share/nginx/html;
+            add_header Content-Security-Policy $csp_header always;
+            add_header X-Content-Type-Options "nosniff" always;
             add_header Cache-Control "public, max-age=604800";
         }
 


### PR DESCRIPTION
## Summary
- Use nginx `map` directive to make CSP header reusable across locations
- Explicitly add security headers in sub-locations (nginx doesn't inherit `add_header` from parent blocks)
- Set `root` directive at server level for cleaner config

## Problem
The CSP header was only applied to the main `/` location. Other locations like `/sw.js`, `/manifest.json`, and `/icons/` had their own `add_header` directives which caused nginx to NOT inherit the parent's security headers.

This caused the browser to block `https://cdn.jsdelivr.net/npm/marked/marked.min.js` even though it was in the CSP.

## Test plan
- [ ] Verify CSP header is present on all responses
- [ ] Verify marked.js loads without CSP errors
- [ ] Verify icons load correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)