### PR TITLE
fix: use --omit=dev instead of deprecated --only=production in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 
 # Copy package files and install dependencies
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
 # Copy all application files including custom overrides
 COPY . .


### PR DESCRIPTION
## Summary
Replace deprecated `--only=production` flag with `--omit=dev` in the backend Dockerfile.

## Problem
The Docker build was failing with:
```
ERROR: failed to build: failed to solve: process "/bin/sh -c npm ci --only=production" did not complete successfully: exit code: 1
```

The `--only=production` flag was removed in npm 9+.

## Solution
Use `--omit=dev` which is the modern equivalent.

## Test plan
- [ ] Verify Docker build succeeds
- [ ] Verify backend starts correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)