### PR TITLE
fix: sync package-lock.json with package.json

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "body-parser": "^2.2.2",
         "cheerio": "^1.0.0",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
         "pg": "^8.13.1",
@@ -488,6 +489,17 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {


### PR DESCRIPTION
## Summary
Sync `package-lock.json` with `package.json` to fix Docker build.

## Problem
The Docker build was failing with:
```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: dotenv@16.6.1 from lock file
```

## Solution
Run `npm install` to regenerate the lock file with all dependencies from `package.json`.

## Test plan
- [ ] Verify Docker build succeeds
- [ ] Verify release workflow completes


🤖 Generated with [Claude Code](https://claude.com/claude-code)