### PR TITLE
feat: Speisekammer-Integration in Einkaufsliste (#152)

### DIFF
--- a/backend/__tests__/utils/unit-conversion.test.js
+++ b/backend/__tests__/utils/unit-conversion.test.js
@@ -1,0 +1,219 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    getUnitInfo,
+    convertUnit,
+    normalizeToBase,
+    normalizeIngredientName,
+    parseAmount,
+    areUnitsCompatible,
+} = require('../../utils/unit-conversion');
+
+describe('getUnitInfo', () => {
+    it('should identify weight units', () => {
+        assert.deepStrictEqual(getUnitInfo('g'), { group: 'weight', factor: 1 });
+        assert.deepStrictEqual(getUnitInfo('kg'), { group: 'weight', factor: 1000 });
+        assert.deepStrictEqual(getUnitInfo('Gramm'), { group: 'weight', factor: 1 });
+    });
+
+    it('should identify volume units', () => {
+        assert.deepStrictEqual(getUnitInfo('ml'), { group: 'volume', factor: 1 });
+        assert.deepStrictEqual(getUnitInfo('l'), { group: 'volume', factor: 1000 });
+        assert.deepStrictEqual(getUnitInfo('EL'), { group: 'volume', factor: 15 });
+        assert.deepStrictEqual(getUnitInfo('TL'), { group: 'volume', factor: 5 });
+        assert.deepStrictEqual(getUnitInfo('cl'), { group: 'volume', factor: 10 });
+    });
+
+    it('should identify count units', () => {
+        const info = getUnitInfo('Stück');
+        assert.equal(info.group, 'count');
+        assert.equal(info.factor, 1);
+    });
+
+    it('should return null for unknown units', () => {
+        assert.equal(getUnitInfo('xyz'), null);
+        assert.equal(getUnitInfo(''), null);
+        assert.equal(getUnitInfo(null), null);
+    });
+
+    it('should handle trailing dots', () => {
+        const info = getUnitInfo('Stk.');
+        assert.equal(info.group, 'count');
+    });
+});
+
+describe('convertUnit', () => {
+    it('should convert g to kg', () => {
+        assert.equal(convertUnit(1000, 'g', 'kg'), 1);
+    });
+
+    it('should convert kg to g', () => {
+        assert.equal(convertUnit(1.5, 'kg', 'g'), 1500);
+    });
+
+    it('should convert ml to l', () => {
+        assert.equal(convertUnit(500, 'ml', 'l'), 0.5);
+    });
+
+    it('should convert l to ml', () => {
+        assert.equal(convertUnit(2, 'l', 'ml'), 2000);
+    });
+
+    it('should convert cl to ml', () => {
+        assert.equal(convertUnit(25, 'cl', 'ml'), 250);
+    });
+
+    it('should convert EL to ml', () => {
+        assert.equal(convertUnit(3, 'EL', 'ml'), 45);
+    });
+
+    it('should return null for incompatible units', () => {
+        assert.equal(convertUnit(100, 'g', 'ml'), null);
+        assert.equal(convertUnit(1, 'kg', 'l'), null);
+    });
+
+    it('should return null for invalid amount', () => {
+        assert.equal(convertUnit(NaN, 'g', 'kg'), null);
+        assert.equal(convertUnit('abc', 'g', 'kg'), null);
+    });
+
+    it('should return null for unknown units', () => {
+        assert.equal(convertUnit(100, 'xyz', 'g'), null);
+    });
+});
+
+describe('normalizeToBase', () => {
+    it('should normalize kg to g', () => {
+        assert.deepStrictEqual(normalizeToBase(2, 'kg'), { amount: 2000, unit: 'g' });
+    });
+
+    it('should normalize l to ml', () => {
+        assert.deepStrictEqual(normalizeToBase(0.5, 'l'), { amount: 500, unit: 'ml' });
+    });
+
+    it('should keep g as g', () => {
+        assert.deepStrictEqual(normalizeToBase(250, 'g'), { amount: 250, unit: 'g' });
+    });
+
+    it('should keep ml as ml', () => {
+        assert.deepStrictEqual(normalizeToBase(100, 'ml'), { amount: 100, unit: 'ml' });
+    });
+
+    it('should normalize EL to ml', () => {
+        assert.deepStrictEqual(normalizeToBase(2, 'EL'), { amount: 30, unit: 'ml' });
+    });
+
+    it('should return null for unknown unit', () => {
+        assert.equal(normalizeToBase(100, 'xyz'), null);
+    });
+});
+
+describe('normalizeIngredientName', () => {
+    it('should lowercase and trim', () => {
+        assert.equal(normalizeIngredientName('  Tomate  '), 'tomat');
+    });
+
+    it('should strip plural suffix -n (Karotten → karott)', () => {
+        const a = normalizeIngredientName('Karotten');
+        const b = normalizeIngredientName('Karotte');
+        assert.equal(a, b);
+    });
+
+    it('should strip plural suffix -en (Tomaten → tomat)', () => {
+        const a = normalizeIngredientName('Tomaten');
+        const b = normalizeIngredientName('Tomate');
+        assert.equal(a, b);
+    });
+
+    it('should match Zwiebel and Zwiebeln', () => {
+        const a = normalizeIngredientName('Zwiebeln');
+        const b = normalizeIngredientName('Zwiebel');
+        assert.equal(a, b);
+    });
+
+    it('should match Kartoffel and Kartoffeln', () => {
+        const a = normalizeIngredientName('Kartoffeln');
+        const b = normalizeIngredientName('Kartoffel');
+        assert.equal(a, b);
+    });
+
+    it('should remove parenthetical info', () => {
+        assert.equal(
+            normalizeIngredientName('Butter (weich)'),
+            normalizeIngredientName('Butter')
+        );
+    });
+
+    it('should not strip from short words', () => {
+        assert.equal(normalizeIngredientName('Ei'), 'ei');
+        assert.equal(normalizeIngredientName('Öl'), 'öl');
+    });
+
+    it('should handle empty/null input', () => {
+        assert.equal(normalizeIngredientName(''), '');
+        assert.equal(normalizeIngredientName(null), '');
+    });
+
+    it('should collapse whitespace', () => {
+        assert.equal(
+            normalizeIngredientName('rote   Zwiebel'),
+            normalizeIngredientName('rote Zwiebel')
+        );
+    });
+});
+
+describe('parseAmount', () => {
+    it('should parse integer strings', () => {
+        assert.equal(parseAmount('3'), 3);
+    });
+
+    it('should parse decimal strings with dot', () => {
+        assert.equal(parseAmount('1.5'), 1.5);
+    });
+
+    it('should parse decimal strings with comma', () => {
+        assert.equal(parseAmount('1,5'), 1.5);
+    });
+
+    it('should parse fractions', () => {
+        assert.equal(parseAmount('1/2'), 0.5);
+        assert.equal(parseAmount('3/4'), 0.75);
+    });
+
+    it('should parse mixed numbers', () => {
+        assert.equal(parseAmount('1 1/2'), 1.5);
+        assert.equal(parseAmount('2 1/4'), 2.25);
+    });
+
+    it('should pass through numbers', () => {
+        assert.equal(parseAmount(42), 42);
+    });
+
+    it('should return null for non-parseable', () => {
+        assert.equal(parseAmount('abc'), null);
+        assert.equal(parseAmount(''), null);
+        assert.equal(parseAmount(null), null);
+    });
+
+    it('should return null for division by zero', () => {
+        assert.equal(parseAmount('1/0'), null);
+    });
+});
+
+describe('areUnitsCompatible', () => {
+    it('should return true for same group', () => {
+        assert.equal(areUnitsCompatible('g', 'kg'), true);
+        assert.equal(areUnitsCompatible('ml', 'l'), true);
+        assert.equal(areUnitsCompatible('Stück', 'Stk'), true);
+    });
+
+    it('should return false for different groups', () => {
+        assert.equal(areUnitsCompatible('g', 'ml'), false);
+        assert.equal(areUnitsCompatible('kg', 'l'), false);
+        assert.equal(areUnitsCompatible('Stück', 'g'), false);
+    });
+
+    it('should return false for unknown units', () => {
+        assert.equal(areUnitsCompatible('xyz', 'g'), false);
+    });
+});

--- a/backend/routes/shopping.js
+++ b/backend/routes/shopping.js
@@ -6,6 +6,7 @@ const { genAI } = require('../utils/gemini');
 const { aiLimiter } = require('../middleware/rate-limiters');
 const { sanitizeForPrompt, extractJsonFromAiResponse } = require('../utils/ai-sanitize');
 const { authenticateRequired } = require('../middleware/authenticate');
+const { normalizeIngredientName, normalizeToBase, parseAmount, areUnitsCompatible, convertUnit } = require('../utils/unit-conversion');
 
 // ========== MANUAL SHOPPING ITEMS ==========
 
@@ -172,6 +173,135 @@ router.delete('/substitutions/:id', authenticateRequired, async (req, res) => {
     } catch (error) {
         logger.error('Error deactivating substitution', { error: error.message, substitutionId: req.params.id, requestId: req.requestId, component: 'substitutions' });
         res.status(500).json({ error: 'Interner Serverfehler' });
+    }
+});
+
+// ========== PANTRY CHECK ==========
+
+// Check shopping list items against pantry inventory
+router.post('/check-pantry', authenticateRequired, async (req, res) => {
+    try {
+        const { items } = req.body;
+
+        if (!Array.isArray(items) || items.length === 0) {
+            return res.status(400).json({ error: 'items array is required' });
+        }
+
+        if (items.length > 200) {
+            return res.status(400).json({ error: 'Maximum 200 items allowed' });
+        }
+
+        // Fetch all pantry items
+        const { rows: pantryItems } = await db.query(
+            'SELECT id, name, quantity, unit FROM pantry_items ORDER BY name'
+        );
+
+        // Build a lookup map: normalized name → [pantry items]
+        const pantryMap = new Map();
+        for (const p of pantryItems) {
+            const key = normalizeIngredientName(p.name);
+            if (!key) continue;
+            if (!pantryMap.has(key)) pantryMap.set(key, []);
+            pantryMap.get(key).push(p);
+        }
+
+        // Check each shopping item against pantry
+        const results = items.map(item => {
+            const name = String(item.name || '').slice(0, 200);
+            const unit = String(item.unit || '').slice(0, 50);
+            const amount = parseAmount(item.amount);
+            const normalizedName = normalizeIngredientName(name);
+
+            const result = {
+                name,
+                amount: item.amount,
+                unit,
+                pantryAmount: 0,
+                pantryUnit: null,
+                adjustedAmount: item.amount,
+                fullyAvailable: false,
+                partiallyAvailable: false,
+            };
+
+            if (!normalizedName) return result;
+
+            // Find matching pantry items
+            const matches = pantryMap.get(normalizedName);
+            if (!matches || matches.length === 0) return result;
+
+            // Sum up all matching pantry quantities
+            let totalPantryInBase = 0;
+            let pantryUnit = matches[0].unit || unit;
+            let hasCompatibleUnits = false;
+
+            for (const match of matches) {
+                const pAmount = parseAmount(match.quantity);
+                if (pAmount === null || pAmount <= 0) continue;
+
+                const pUnit = match.unit || '';
+
+                // If shopping item has no parseable amount, just mark as available
+                if (amount === null) {
+                    result.fullyAvailable = true;
+                    result.pantryAmount = pAmount;
+                    result.pantryUnit = pUnit;
+                    return result;
+                }
+
+                // Try to convert to same unit system
+                if (areUnitsCompatible(pUnit, unit)) {
+                    hasCompatibleUnits = true;
+                    const converted = convertUnit(pAmount, pUnit, unit);
+                    if (converted !== null) {
+                        totalPantryInBase += converted;
+                    }
+                } else if (!pUnit && !unit) {
+                    // Both unitless
+                    hasCompatibleUnits = true;
+                    totalPantryInBase += pAmount;
+                }
+            }
+
+            if (!hasCompatibleUnits) {
+                // Units incompatible — still report pantry has it, but can't calculate
+                result.pantryAmount = matches.reduce((sum, m) => {
+                    const a = parseAmount(m.quantity);
+                    return a !== null ? sum + a : sum;
+                }, 0);
+                result.pantryUnit = matches[0].unit;
+                result.partiallyAvailable = true;
+                return result;
+            }
+
+            result.pantryAmount = Math.round(totalPantryInBase * 100) / 100;
+            result.pantryUnit = unit;
+
+            if (amount !== null && totalPantryInBase >= amount) {
+                result.fullyAvailable = true;
+                result.adjustedAmount = 0;
+            } else if (amount !== null && totalPantryInBase > 0) {
+                result.partiallyAvailable = true;
+                result.adjustedAmount = Math.round((amount - totalPantryInBase) * 100) / 100;
+            }
+
+            return result;
+        });
+
+        const fullyAvailableCount = results.filter(r => r.fullyAvailable).length;
+        const partiallyAvailableCount = results.filter(r => r.partiallyAvailable).length;
+
+        res.json({
+            items: results,
+            summary: {
+                totalItems: results.length,
+                fullyAvailable: fullyAvailableCount,
+                partiallyAvailable: partiallyAvailableCount,
+                toBuy: results.length - fullyAvailableCount,
+            }
+        });
+    } catch (error) {
+        logger.error('Pantry check error', { error: error.message, requestId: req.requestId, component: 'shopping' });
+        res.status(500).json({ error: 'Fehler beim Vorratsabgleich' });
     }
 });
 

--- a/backend/utils/unit-conversion.js
+++ b/backend/utils/unit-conversion.js
@@ -1,0 +1,194 @@
+/**
+ * Unit conversion and ingredient name normalization utilities.
+ * Used for matching shopping list items against pantry inventory.
+ */
+
+// Weight units → base unit grams
+const WEIGHT_UNITS = {
+    g: 1,
+    gramm: 1,
+    kg: 1000,
+    kilogramm: 1000,
+    mg: 0.001,
+    pfund: 500,
+};
+
+// Volume units → base unit milliliters
+const VOLUME_UNITS = {
+    ml: 1,
+    milliliter: 1,
+    l: 1000,
+    liter: 1000,
+    cl: 10,
+    zentiliter: 10,
+    dl: 100,
+    deziliter: 100,
+    el: 15,   // Esslöffel ≈ 15ml
+    tl: 5,    // Teelöffel ≈ 5ml
+};
+
+// Count/piece units — not convertible, matched directly
+const COUNT_UNITS = new Set([
+    'stück', 'stk', 'stk.', 'scheibe', 'scheiben',
+    'packung', 'pkg', 'pck', 'dose', 'dosen',
+    'flasche', 'flaschen', 'bund', 'beutel',
+    'zehe', 'zehen', 'prise', 'prisen',
+    'becher', 'glas', 'gläser', 'tasse', 'tassen',
+]);
+
+/**
+ * Get the unit group (weight, volume, count) and conversion factor to base unit.
+ * @param {string} unit
+ * @returns {{ group: string, factor: number } | null}
+ */
+function getUnitInfo(unit) {
+    if (!unit || typeof unit !== 'string') return null;
+    const normalized = unit.trim().toLowerCase().replace(/\.$/, '');
+
+    if (WEIGHT_UNITS[normalized] !== undefined) {
+        return { group: 'weight', factor: WEIGHT_UNITS[normalized] };
+    }
+    if (VOLUME_UNITS[normalized] !== undefined) {
+        return { group: 'volume', factor: VOLUME_UNITS[normalized] };
+    }
+    if (COUNT_UNITS.has(normalized)) {
+        return { group: 'count', factor: 1 };
+    }
+    return null;
+}
+
+/**
+ * Convert an amount from one unit to another (within the same group).
+ * Returns null if units are incompatible.
+ * @param {number} amount
+ * @param {string} fromUnit
+ * @param {string} toUnit
+ * @returns {number | null}
+ */
+function convertUnit(amount, fromUnit, toUnit) {
+    if (typeof amount !== 'number' || isNaN(amount)) return null;
+
+    const from = getUnitInfo(fromUnit);
+    const to = getUnitInfo(toUnit);
+
+    if (!from || !to) return null;
+    if (from.group !== to.group) return null;
+
+    // Convert: source → base → target
+    const baseAmount = amount * from.factor;
+    return baseAmount / to.factor;
+}
+
+/**
+ * Normalize an amount+unit to the base unit of its group (g for weight, ml for volume).
+ * Returns { amount, unit } or null if unknown unit.
+ * @param {number} amount
+ * @param {string} unit
+ * @returns {{ amount: number, unit: string } | null}
+ */
+function normalizeToBase(amount, unit) {
+    if (typeof amount !== 'number' || isNaN(amount)) return null;
+
+    const info = getUnitInfo(unit);
+    if (!info) return null;
+
+    if (info.group === 'weight') {
+        return { amount: amount * info.factor, unit: 'g' };
+    }
+    if (info.group === 'volume') {
+        return { amount: amount * info.factor, unit: 'ml' };
+    }
+    // Count units: keep as-is
+    return { amount, unit: unit.trim().toLowerCase() };
+}
+
+/**
+ * German plural suffixes to strip for ingredient name normalization.
+ * Order matters — longer suffixes first to avoid partial matches.
+ */
+const PLURAL_SUFFIXES = ['en', 'n', 'e', 's'];
+
+/**
+ * Normalize an ingredient name for fuzzy matching.
+ * Lowercase, trim, strip common German plural suffixes.
+ * @param {string} name
+ * @returns {string}
+ */
+function normalizeIngredientName(name) {
+    if (!name || typeof name !== 'string') return '';
+    let normalized = name.trim().toLowerCase();
+
+    // Remove parenthetical info like "(frisch)" or "(500g)"
+    normalized = normalized.replace(/\s*\(.*?\)\s*/g, ' ').trim();
+
+    // Collapse whitespace
+    normalized = normalized.replace(/\s+/g, ' ');
+
+    // Don't strip suffixes from very short words (< 4 chars)
+    if (normalized.length < 4) return normalized;
+
+    // Try stripping plural suffixes
+    for (const suffix of PLURAL_SUFFIXES) {
+        if (normalized.endsWith(suffix) && normalized.length - suffix.length >= 3) {
+            return normalized.slice(0, -suffix.length);
+        }
+    }
+
+    return normalized;
+}
+
+/**
+ * Parse a numeric amount from a string that may contain fractions or ranges.
+ * @param {string|number} value
+ * @returns {number|null}
+ */
+function parseAmount(value) {
+    if (typeof value === 'number') return isNaN(value) ? null : value;
+    if (!value || typeof value !== 'string') return null;
+
+    const trimmed = value.trim();
+
+    // Direct numeric
+    const num = Number(trimmed.replace(',', '.'));
+    if (!isNaN(num)) return num;
+
+    // Fraction like "1/2"
+    const fractionMatch = trimmed.match(/^(\d+)\s*\/\s*(\d+)$/);
+    if (fractionMatch) {
+        const denom = Number(fractionMatch[2]);
+        if (denom === 0) return null;
+        return Number(fractionMatch[1]) / denom;
+    }
+
+    // Mixed number like "1 1/2"
+    const mixedMatch = trimmed.match(/^(\d+)\s+(\d+)\s*\/\s*(\d+)$/);
+    if (mixedMatch) {
+        const denom = Number(mixedMatch[3]);
+        if (denom === 0) return null;
+        return Number(mixedMatch[1]) + Number(mixedMatch[2]) / denom;
+    }
+
+    return null;
+}
+
+/**
+ * Check if two unit strings are in the same unit group (both weight, both volume, etc.).
+ * @param {string} unitA
+ * @param {string} unitB
+ * @returns {boolean}
+ */
+function areUnitsCompatible(unitA, unitB) {
+    const infoA = getUnitInfo(unitA);
+    const infoB = getUnitInfo(unitB);
+    if (!infoA || !infoB) return false;
+    return infoA.group === infoB.group;
+}
+
+module.exports = {
+    getUnitInfo,
+    convertUnit,
+    normalizeToBase,
+    normalizeIngredientName,
+    parseAmount,
+    areUnitsCompatible,
+};

--- a/js/core/storage-service.js
+++ b/js/core/storage-service.js
@@ -217,6 +217,15 @@ export const StorageService = {
         }
     },
 
+    async checkPantryAvailability(items) {
+        try {
+            return await api.post(`${API_BASE_URL}/shopping/check-pantry`, { items });
+        } catch (error) {
+            console.error('Error checking pantry availability:', error);
+            return { items: [], summary: { totalItems: 0, fullyAvailable: 0, partiallyAvailable: 0, toBuy: 0 } };
+        }
+    },
+
     // Cooking History methods
     async getCookingHistory(page = 1, limit = 20) {
         try {

--- a/js/views/shopping-list.js
+++ b/js/views/shopping-list.js
@@ -16,6 +16,8 @@ export const ShoppingListView = {
     optimizationResult: null,
     isOptimizing: false,
     showOptimizationModal: false,
+    usePantry: localStorage.getItem('shopping_use_pantry') !== 'false', // default: true
+    pantryCheckResult: null,
     preferences: {
         prioritizeSeasonal: false,
         prioritizeOrganic: false,
@@ -97,6 +99,9 @@ export const ShoppingListView = {
                     </div>
                 </div>
 
+                <!-- Pantry Toggle & Banner -->
+                ${this.renderPantryPanel()}
+
                 <!-- Optimization Result -->
                 ${this.optimizationResult ? this.renderOptimizationResult() : ''}
 
@@ -163,6 +168,38 @@ export const ShoppingListView = {
                         `}
                     </button>
                 </div>
+            </div>
+        `;
+    },
+
+    renderPantryPanel() {
+        const summary = this.pantryCheckResult?.summary;
+        const hasDeductions = summary && (summary.fullyAvailable > 0 || summary.partiallyAvailable > 0);
+
+        return `
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-900 p-4 transition-colors duration-200">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <svg class="w-5 h-5 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"></path>
+                        </svg>
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Vorräte berücksichtigen</span>
+                    </div>
+                    <label class="relative inline-flex items-center cursor-pointer">
+                        <input type="checkbox" id="pantry-toggle" class="sr-only peer" ${this.usePantry ? 'checked' : ''}>
+                        <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-amber-300 dark:peer-focus:ring-amber-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:after:border-gray-600 peer-checked:bg-amber-500"></div>
+                    </label>
+                </div>
+                ${hasDeductions ? `
+                    <div class="mt-3 flex items-center gap-2 text-sm text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-900/20 rounded-lg p-2">
+                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                        <span>
+                            ${summary.fullyAvailable} Zutat${summary.fullyAvailable !== 1 ? 'en' : ''} vollständig im Vorrat${summary.partiallyAvailable > 0 ? `, ${summary.partiallyAvailable} teilweise vorhanden` : ''}
+                        </span>
+                    </div>
+                ` : ''}
             </div>
         `;
     },
@@ -418,8 +455,15 @@ export const ShoppingListView = {
                     </div>
 
                     <div class="divide-y dark:divide-gray-700 ${isCollapsed ? 'hidden' : ''}">
-                        ${items.map(item => `
-                            <div class="p-3 sm:p-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors ${item.checked ? 'bg-gray-50 dark:bg-gray-700/50' : ''} ${item.isManual ? 'border-l-4 border-green-500 dark:border-green-600' : ''}">
+                        ${items.map(item => {
+                            const pantryInfo = item.pantryInfo;
+                            const isFullyAvailable = pantryInfo?.fullyAvailable;
+                            const isPartial = pantryInfo?.partiallyAvailable;
+                            const displayAmount = pantryInfo ? pantryInfo.adjustedAmount : item.amount;
+                            const strikeClass = isFullyAvailable ? 'line-through text-gray-400 dark:text-gray-500' : '';
+
+                            return `
+                            <div class="p-3 sm:p-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors ${item.checked || isFullyAvailable ? 'bg-gray-50 dark:bg-gray-700/50' : ''} ${item.isManual ? 'border-l-4 border-green-500 dark:border-green-600' : ''} ${isFullyAvailable ? 'opacity-60' : ''}">
                                 <div class="flex items-center gap-3 sm:gap-4">
                                     <!-- Large touch-friendly checkbox -->
                                     <label class="relative flex items-center justify-center cursor-pointer">
@@ -429,9 +473,10 @@ export const ShoppingListView = {
                                     </label>
                                     <div class="flex-1 min-w-0 cursor-pointer py-1" data-item-index="${item.index}">
                                         <div class="flex items-start justify-between gap-2">
-                                            <p class="font-medium text-gray-800 dark:text-white text-sm sm:text-base ${item.checked ? 'line-through text-gray-500 dark:text-gray-400' : ''}">
-                                                <span class="font-semibold">${item.amount}</span> ${item.unit} ${item.name}
+                                            <p class="font-medium text-gray-800 dark:text-white text-sm sm:text-base ${item.checked ? 'line-through text-gray-500 dark:text-gray-400' : ''} ${strikeClass}">
+                                                <span class="font-semibold">${isFullyAvailable ? item.amount : displayAmount}</span> ${item.unit} ${item.name}
                                                 ${item.isManual ? '<span class="ml-2 text-xs bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300 px-2 py-0.5 rounded">Manuell</span>' : ''}
+                                                ${isFullyAvailable ? '<span class="ml-2 text-xs bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300 px-2 py-0.5 rounded">Im Vorrat</span>' : ''}
                                             </p>
                                             ${item.isManual ? `
                                                 <button class="delete-manual-item-btn p-2 -mr-2 text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
@@ -443,6 +488,11 @@ export const ShoppingListView = {
                                                 </button>
                                             ` : ''}
                                         </div>
+                                        ${isPartial && pantryInfo.pantryAmount > 0 ? `
+                                            <p class="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
+                                                ${pantryInfo.pantryAmount} ${pantryInfo.pantryUnit || item.unit} im Vorrat
+                                            </p>
+                                        ` : ''}
                                         ${item.recipeNames.length > 0 ? `
                                             <p class="text-xs sm:text-sm text-gray-500 dark:text-gray-400 mt-1 truncate">
                                                 Für: ${item.recipeNames.join(', ')}
@@ -451,7 +501,7 @@ export const ShoppingListView = {
                                     </div>
                                 </div>
                             </div>
-                        `).join('')}
+                        `}).join('')}
                     </div>
                 </div>
             `;
@@ -521,6 +571,44 @@ export const ShoppingListView = {
         this.shoppingList = Array.from(ingredientsMap.values()).sort((a, b) =>
             a.name.localeCompare(b.name)
         );
+
+        // Check pantry availability if enabled
+        if (this.usePantry && this.shoppingList.length > 0) {
+            try {
+                const itemsToCheck = this.shoppingList
+                    .filter(item => !item.isManual)
+                    .map(item => ({ name: item.name, amount: item.amount, unit: item.unit }));
+
+                if (itemsToCheck.length > 0) {
+                    this.pantryCheckResult = await StorageService.checkPantryAvailability(itemsToCheck);
+
+                    // Merge pantry info into shopping list items
+                    if (this.pantryCheckResult?.items) {
+                        const pantryMap = new Map();
+                        for (const pItem of this.pantryCheckResult.items) {
+                            pantryMap.set(`${pItem.name.toLowerCase()}_${pItem.unit.toLowerCase()}`, pItem);
+                        }
+                        for (const item of this.shoppingList) {
+                            if (item.isManual) continue;
+                            const key = `${item.name.toLowerCase()}_${item.unit.toLowerCase()}`;
+                            const pantryInfo = pantryMap.get(key);
+                            if (pantryInfo && (pantryInfo.fullyAvailable || pantryInfo.partiallyAvailable)) {
+                                item.pantryInfo = pantryInfo;
+                            }
+                        }
+                    }
+                }
+            } catch {
+                // Silently fail — shopping list works without pantry check
+                this.pantryCheckResult = null;
+            }
+        } else {
+            this.pantryCheckResult = null;
+            // Clear pantry info from items
+            for (const item of this.shoppingList) {
+                delete item.pantryInfo;
+            }
+        }
     },
 
     attachEventListeners() {
@@ -611,6 +699,17 @@ export const ShoppingListView = {
                 await this.deleteManualItem(itemId);
             });
         });
+
+        // Pantry toggle
+        const pantryToggle = document.getElementById('pantry-toggle');
+        if (pantryToggle) {
+            pantryToggle.addEventListener('change', async (e) => {
+                this.usePantry = e.target.checked;
+                localStorage.setItem('shopping_use_pantry', String(this.usePantry));
+                await this.generateShoppingList();
+                App.render();
+            });
+        }
 
         // Budget slider
         const budgetSlider = document.getElementById('budget-slider');


### PR DESCRIPTION
## Summary
- Einkaufsliste wird automatisch gegen Speisekammer-Vorräte abgeglichen
- Vorhandene Mengen werden abgezogen, vollständig verfügbare Zutaten visuell markiert
- Toggle zum Aktivieren/Deaktivieren des Abgleichs (persistiert in localStorage)
- Einheitenkonvertierung (g↔kg, ml↔l, EL/TL→ml) und Fuzzy-Matching für deutsche Zutatennamen (Plural-Normalisierung)

## Änderungen
- **`backend/utils/unit-conversion.js`** — Neues Utility: `convertUnit`, `normalizeIngredientName`, `parseAmount`, `areUnitsCompatible`, `normalizeToBase`, `getUnitInfo`
- **`backend/__tests__/utils/unit-conversion.test.js`** — 40 Unit-Tests für alle Konvertierungsfunktionen
- **`backend/routes/shopping.js`** — Neuer `POST /shopping/check-pantry` Endpoint
- **`js/core/storage-service.js`** — Neue `checkPantryAvailability()` Methode
- **`js/views/shopping-list.js`** — Pantry-Toggle, Info-Banner, "Im Vorrat"-Badges, angepasste Mengen

## Test plan
- [ ] Container neu starten (`down` + `up`)
- [ ] Speisekammer mit Testdaten befüllen (Zutaten die auch in Rezepten vorkommen)
- [ ] Einkaufsliste generieren → vorhandene Zutaten werden markiert/abgezogen
- [ ] Pantry-Toggle aus → alle Zutaten ohne Abzug angezeigt
- [ ] Toggle-Zustand überlebt Seite neu laden (localStorage)
- [ ] Teilmengen: z.B. 200g Mehl vorhanden, 500g gebraucht → zeigt "200g im Vorrat", Menge = 300g
- [ ] Einheiten-Konvertierung: 1kg im Vorrat vs. 500g im Rezept → korrekt erkannt
- [ ] Pluralformen: "Tomaten" vs. "Tomate" → Fuzzy-Match
- [ ] Leere Speisekammer → kein Banner, normale Anzeige
- [ ] `npm test` → 277 Tests bestehen (237 + 40 neue)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)