### PR TITLE
feat: Auth auf Username umbauen + Admin-Setup beim ersten Start

### DIFF
--- a/backend/__tests__/utils/auth.test.js
+++ b/backend/__tests__/utils/auth.test.js
@@ -37,11 +37,22 @@ function validatePassword(password) {
     return { valid: true };
 }
 
+function validateUsername(username) {
+    if (!username || typeof username !== 'string') return { valid: false, error: 'Username is required' };
+    const trimmed = username.trim();
+    if (trimmed.length < 3) return { valid: false, error: 'Username must be at least 3 characters' };
+    if (trimmed.length > 50) return { valid: false, error: 'Username must be at most 50 characters' };
+    if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) return { valid: false, error: 'Username may only contain letters, numbers, underscore and hyphen' };
+    return { valid: true };
+}
+
 function createUserPayload(user) {
     return {
         sub: user.id,
-        email: user.email,
-        name: user.name || ''
+        username: user.username,
+        email: user.email || '',
+        name: user.name || '',
+        role: user.role || 'user'
     };
 }
 
@@ -156,33 +167,113 @@ describe('validatePassword', () => {
     });
 });
 
+describe('validateUsername', () => {
+    it('should accept a valid username', () => {
+        const result = validateUsername('alice');
+        assert.strictEqual(result.valid, true);
+    });
+
+    it('should accept username with numbers, underscores and hyphens', () => {
+        assert.strictEqual(validateUsername('user_name-123').valid, true);
+    });
+
+    it('should accept exactly 3 characters', () => {
+        assert.strictEqual(validateUsername('abc').valid, true);
+    });
+
+    it('should accept exactly 50 characters', () => {
+        assert.strictEqual(validateUsername('a'.repeat(50)).valid, true);
+    });
+
+    it('should reject username shorter than 3 characters', () => {
+        const result = validateUsername('ab');
+        assert.strictEqual(result.valid, false);
+        assert.ok(result.error.includes('3'));
+    });
+
+    it('should reject username longer than 50 characters', () => {
+        const result = validateUsername('a'.repeat(51));
+        assert.strictEqual(result.valid, false);
+        assert.ok(result.error.includes('50'));
+    });
+
+    it('should reject username with spaces', () => {
+        const result = validateUsername('user name');
+        assert.strictEqual(result.valid, false);
+    });
+
+    it('should reject username with special characters', () => {
+        const result = validateUsername('user@name');
+        assert.strictEqual(result.valid, false);
+    });
+
+    it('should reject empty string', () => {
+        const result = validateUsername('');
+        assert.strictEqual(result.valid, false);
+    });
+
+    it('should reject null', () => {
+        const result = validateUsername(null);
+        assert.strictEqual(result.valid, false);
+    });
+
+    it('should reject non-string', () => {
+        const result = validateUsername(42);
+        assert.strictEqual(result.valid, false);
+    });
+});
+
 describe('createUserPayload', () => {
     it('should map user id to sub claim', () => {
-        const user = { id: 'abc-123', email: 'user@example.com', name: 'Alice' };
+        const user = { id: 'abc-123', username: 'alice', email: 'user@example.com', name: 'Alice' };
         const payload = createUserPayload(user);
         assert.strictEqual(payload.sub, 'abc-123');
     });
 
+    it('should include username in payload', () => {
+        const user = { id: 'abc-123', username: 'alice', email: 'user@example.com', name: 'Alice' };
+        const payload = createUserPayload(user);
+        assert.strictEqual(payload.username, 'alice');
+    });
+
     it('should include email in payload', () => {
-        const user = { id: 'abc-123', email: 'user@example.com', name: 'Alice' };
+        const user = { id: 'abc-123', username: 'alice', email: 'user@example.com', name: 'Alice' };
         const payload = createUserPayload(user);
         assert.strictEqual(payload.email, 'user@example.com');
     });
 
+    it('should default email to empty string when missing', () => {
+        const user = { id: 'abc-123', username: 'alice', name: 'Alice' };
+        const payload = createUserPayload(user);
+        assert.strictEqual(payload.email, '');
+    });
+
     it('should include name in payload', () => {
-        const user = { id: 'abc-123', email: 'user@example.com', name: 'Alice' };
+        const user = { id: 'abc-123', username: 'alice', email: 'user@example.com', name: 'Alice' };
         const payload = createUserPayload(user);
         assert.strictEqual(payload.name, 'Alice');
     });
 
     it('should default name to empty string when missing', () => {
-        const user = { id: 'abc-123', email: 'user@example.com' };
+        const user = { id: 'abc-123', username: 'alice', email: 'user@example.com' };
         const payload = createUserPayload(user);
         assert.strictEqual(payload.name, '');
     });
 
+    it('should include role in payload', () => {
+        const user = { id: 'abc-123', username: 'alice', email: 'user@example.com', name: 'Alice', role: 'admin' };
+        const payload = createUserPayload(user);
+        assert.strictEqual(payload.role, 'admin');
+    });
+
+    it('should default role to user', () => {
+        const user = { id: 'abc-123', username: 'alice', email: 'user@example.com', name: 'Alice' };
+        const payload = createUserPayload(user);
+        assert.strictEqual(payload.role, 'user');
+    });
+
     it('should not include password_hash in payload', () => {
-        const user = { id: 'abc-123', email: 'user@example.com', name: 'Alice', password_hash: '$2b$...' };
+        const user = { id: 'abc-123', username: 'alice', email: 'user@example.com', name: 'Alice', password_hash: '$2b$...' };
         const payload = createUserPayload(user);
         assert.strictEqual(payload.password_hash, undefined);
     });

--- a/backend/db/migrations/012_auth_username.sql
+++ b/backend/db/migrations/012_auth_username.sql
@@ -1,0 +1,12 @@
+-- Convert auth from email to username
+ALTER TABLE users ADD COLUMN IF NOT EXISTS username VARCHAR(50);
+
+-- Migrate existing data: use email prefix as username
+UPDATE users SET username = SPLIT_PART(email, '@', 1) WHERE username IS NULL;
+
+-- Make username required and unique
+ALTER TABLE users ALTER COLUMN username SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users (username);
+
+-- Email becomes optional (keep for backwards compatibility but no longer required for login)
+ALTER TABLE users ALTER COLUMN email DROP NOT NULL;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const db = require('../db');
 const { logger } = require('../utils/logger');
-const { validateEmail, hashPassword, generateTempPassword } = require('../utils/auth');
+const { validateUsername, hashPassword, generateTempPassword } = require('../utils/auth');
 const { authenticateRequired, requireAdmin } = require('../middleware/authenticate');
 const { adminLimiter } = require('../middleware/rate-limiters');
 const { logAudit } = require('../utils/audit');
@@ -21,7 +21,7 @@ router.get('/users', async (req, res) => {
         const total = parseInt(countResult.rows[0].count);
 
         const result = await db.query(
-            'SELECT id, email, name, role, is_active, must_change_password, created_at, last_login_at FROM users ORDER BY created_at ASC LIMIT $1 OFFSET $2',
+            'SELECT id, username, email, name, role, is_active, must_change_password, created_at, last_login_at FROM users ORDER BY created_at ASC LIMIT $1 OFFSET $2',
             [limit, offset]
         );
 
@@ -38,32 +38,33 @@ router.get('/users', async (req, res) => {
 // POST /admin/users — create a new user with temporary password
 router.post('/users', async (req, res) => {
     try {
-        const { email, name, role } = req.body;
+        const { username, name, role } = req.body;
 
-        if (!validateEmail(email)) {
-            return res.status(400).json({ error: 'Ungültige E-Mail-Adresse' });
+        const usernameCheck = validateUsername(username);
+        if (!usernameCheck.valid) {
+            return res.status(400).json({ error: usernameCheck.error });
         }
 
         if (role && !['user', 'admin'].includes(role)) {
             return res.status(400).json({ error: 'Ungültige Rolle. Erlaubt: user, admin' });
         }
 
-        const existing = await db.query('SELECT id FROM users WHERE email = $1', [email.trim().toLowerCase()]);
+        const existing = await db.query('SELECT id FROM users WHERE username = $1', [username.trim()]);
         if (existing.rows.length > 0) {
-            return res.status(409).json({ error: 'E-Mail-Adresse bereits registriert' });
+            return res.status(409).json({ error: 'Benutzername bereits vergeben' });
         }
 
         const tempPassword = generateTempPassword();
         const passwordHash = await hashPassword(tempPassword);
 
         const result = await db.query(
-            'INSERT INTO users (email, password_hash, name, role, must_change_password) VALUES ($1, $2, $3, $4, true) RETURNING id, email, name, role, is_active, created_at',
-            [email.trim().toLowerCase(), passwordHash, name ? name.trim() : null, role || 'user']
+            'INSERT INTO users (username, password_hash, name, role, must_change_password) VALUES ($1, $2, $3, $4, true) RETURNING id, username, name, role, is_active, created_at',
+            [username.trim(), passwordHash, name ? name.trim() : null, role || 'user']
         );
 
         const user = result.rows[0];
         logger.info('Admin created user', { targetUserId: user.id, adminId: req.user.id, component: 'admin' });
-        await logAudit(req, 'user.create', 'user', user.id, { email, role });
+        await logAudit(req, 'user.create', 'user', user.id, { username, role });
         res.status(201).json({ user, tempPassword });
     } catch (error) {
         logger.error('Admin create user error', { error: error.message, component: 'admin' });
@@ -86,7 +87,7 @@ router.put('/users/:id/role', async (req, res) => {
         }
 
         const result = await db.query(
-            'UPDATE users SET role = $1 WHERE id = $2 RETURNING id, email, name, role, is_active',
+            'UPDATE users SET role = $1 WHERE id = $2 RETURNING id, username, email, name, role, is_active',
             [role, id]
         );
 
@@ -118,7 +119,7 @@ router.put('/users/:id/status', async (req, res) => {
         }
 
         const result = await db.query(
-            'UPDATE users SET is_active = $1 WHERE id = $2 RETURNING id, email, name, role, is_active',
+            'UPDATE users SET is_active = $1 WHERE id = $2 RETURNING id, username, email, name, role, is_active',
             [is_active, id]
         );
 
@@ -144,7 +145,7 @@ router.put('/users/:id/reset-password', async (req, res) => {
         const passwordHash = await hashPassword(tempPassword);
 
         const result = await db.query(
-            'UPDATE users SET password_hash = $1, must_change_password = true WHERE id = $2 RETURNING id, email, name',
+            'UPDATE users SET password_hash = $1, must_change_password = true WHERE id = $2 RETURNING id, username, name',
             [passwordHash, id]
         );
 
@@ -171,7 +172,7 @@ router.delete('/users/:id', async (req, res) => {
         }
 
         const result = await db.query(
-            'DELETE FROM users WHERE id = $1 RETURNING id, email',
+            'DELETE FROM users WHERE id = $1 RETURNING id, username',
             [id]
         );
 

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const db = require('../db');
 const { logger } = require('../utils/logger');
-const { validateEmail, validatePassword, hashPassword, verifyPassword, generateToken, generateRefreshToken, verifyRefreshToken } = require('../utils/auth');
+const { validateUsername, validatePassword, hashPassword, verifyPassword, generateToken, generateRefreshToken, verifyRefreshToken } = require('../utils/auth');
 const { authenticateRequired } = require('../middleware/authenticate');
 const { authLimiter } = require('../middleware/rate-limiters');
 const { logAudit } = require('../utils/audit');
@@ -56,10 +56,11 @@ function getCookie(req, name) {
 // POST /auth/register
 router.post('/register', authLimiter, validate(registerSchema), async (req, res) => {
     try {
-        const { email, password, name } = req.body;
+        const { username, password, name, email } = req.body;
 
-        if (!validateEmail(email)) {
-            return res.status(400).json({ error: 'Ungültige E-Mail-Adresse' });
+        const usernameCheck = validateUsername(username);
+        if (!usernameCheck.valid) {
+            return res.status(400).json({ error: usernameCheck.error });
         }
 
         const pwCheck = validatePassword(password);
@@ -67,15 +68,15 @@ router.post('/register', authLimiter, validate(registerSchema), async (req, res)
             return res.status(400).json({ error: pwCheck.error });
         }
 
-        const existing = await db.query('SELECT id FROM users WHERE email = $1', [email.trim().toLowerCase()]);
+        const existing = await db.query('SELECT id FROM users WHERE username = $1', [username.trim()]);
         if (existing.rows.length > 0) {
-            return res.status(409).json({ error: 'E-Mail-Adresse bereits registriert' });
+            return res.status(409).json({ error: 'Benutzername bereits vergeben' });
         }
 
         const passwordHash = await hashPassword(password);
         const result = await db.query(
-            'INSERT INTO users (email, password_hash, name) VALUES ($1, $2, $3) RETURNING id, email, name, role, created_at',
-            [email.trim().toLowerCase(), passwordHash, name ? name.trim() : null]
+            'INSERT INTO users (username, email, password_hash, name) VALUES ($1, $2, $3, $4) RETURNING id, username, email, name, role, created_at',
+            [username.trim(), email ? email.trim().toLowerCase() : null, passwordHash, name ? name.trim() : null]
         );
 
         const user = result.rows[0];
@@ -83,7 +84,7 @@ router.post('/register', authLimiter, validate(registerSchema), async (req, res)
         const refreshToken = generateRefreshToken(user);
         setRefreshCookie(res, refreshToken);
         logger.info('User registered', { userId: user.id, component: 'auth' });
-        res.status(201).json({ token, user: { id: user.id, email: user.email, name: user.name, role: user.role } });
+        res.status(201).json({ token, user: { id: user.id, username: user.username, name: user.name, role: user.role } });
     } catch (error) {
         logger.error('Registration error', { error: error.message, component: 'auth' });
         res.status(500).json({ error: 'Registrierung fehlgeschlagen' });
@@ -93,20 +94,20 @@ router.post('/register', authLimiter, validate(registerSchema), async (req, res)
 // POST /auth/login
 router.post('/login', authLimiter, validate(loginSchema), async (req, res) => {
     try {
-        const { email, password } = req.body;
+        const { username, password } = req.body;
 
-        if (!email || !password) {
-            return res.status(400).json({ error: 'E-Mail und Passwort erforderlich' });
+        if (!username || !password) {
+            return res.status(400).json({ error: 'Benutzername und Passwort erforderlich' });
         }
 
         const result = await db.query(
-            'SELECT id, email, name, password_hash, role, is_active, must_change_password FROM users WHERE email = $1',
-            [email.trim().toLowerCase()]
+            'SELECT id, username, email, name, password_hash, role, is_active, must_change_password FROM users WHERE username = $1',
+            [username.trim()]
         );
 
         if (result.rows.length === 0) {
-            await logAudit(req, 'auth.login_failed', 'user', null, { email });
-            return res.status(401).json({ error: 'Ungültige E-Mail oder Passwort' });
+            await logAudit(req, 'auth.login_failed', 'user', null, { username });
+            return res.status(401).json({ error: 'Ungültiger Benutzername oder Passwort' });
         }
 
         const user = result.rows[0];
@@ -117,8 +118,8 @@ router.post('/login', authLimiter, validate(loginSchema), async (req, res) => {
 
         const valid = await verifyPassword(password, user.password_hash);
         if (!valid) {
-            await logAudit(req, 'auth.login_failed', 'user', null, { email });
-            return res.status(401).json({ error: 'Ungültige E-Mail oder Passwort' });
+            await logAudit(req, 'auth.login_failed', 'user', null, { username });
+            return res.status(401).json({ error: 'Ungültiger Benutzername oder Passwort' });
         }
 
         // Update last_login_at
@@ -130,7 +131,7 @@ router.post('/login', authLimiter, validate(loginSchema), async (req, res) => {
         logger.info('User logged in', { userId: user.id, component: 'auth' });
         res.json({
             token,
-            user: { id: user.id, email: user.email, name: user.name, role: user.role },
+            user: { id: user.id, username: user.username, name: user.name, role: user.role },
             mustChangePassword: user.must_change_password
         });
     } catch (error) {
@@ -185,7 +186,7 @@ router.post('/change-password', authenticateRequired, validate(changePasswordSch
 router.get('/me', authenticateRequired, async (req, res) => {
     try {
         const result = await db.query(
-            'SELECT id, email, name, role, created_at FROM users WHERE id = $1',
+            'SELECT id, username, email, name, role, created_at FROM users WHERE id = $1',
             [req.user.id]
         );
         if (result.rows.length === 0) {
@@ -214,7 +215,7 @@ router.post('/refresh', async (req, res) => {
         }
 
         const result = await db.query(
-            'SELECT id, email, name, role, is_active FROM users WHERE id = $1',
+            'SELECT id, username, email, name, role, is_active FROM users WHERE id = $1',
             [payload.sub]
         );
 
@@ -228,7 +229,7 @@ router.post('/refresh', async (req, res) => {
         // Rotate refresh token — issue a new one with each refresh
         const newRefreshToken = generateRefreshToken(user);
         setRefreshCookie(res, newRefreshToken);
-        res.json({ token: newToken, user: { id: user.id, email: user.email, name: user.name, role: user.role } });
+        res.json({ token: newToken, user: { id: user.id, username: user.username, name: user.name, role: user.role } });
     } catch (error) {
         logger.error('Token refresh error', { error: error.message, component: 'auth' });
         res.status(500).json({ error: 'Token-Refresh fehlgeschlagen' });

--- a/backend/schemas/auth.js
+++ b/backend/schemas/auth.js
@@ -1,14 +1,15 @@
 const { z } = require('zod');
 
 const loginSchema = z.object({
-    email: z.string().email().max(255),
+    username: z.string().min(1).max(50),
     password: z.string().min(1).max(128),
 });
 
 const registerSchema = z.object({
-    email: z.string().email().max(255),
+    username: z.string().min(3).max(50).regex(/^[a-zA-Z0-9_-]+$/, 'Username may only contain letters, numbers, underscore and hyphen'),
     password: z.string().min(8).max(128),
     name: z.string().max(255).optional(),
+    email: z.string().email().max(255).optional(),
 });
 
 const changePasswordSchema = z.object({

--- a/backend/server.js
+++ b/backend/server.js
@@ -124,6 +124,23 @@ const startServer = async () => {
         // Run migrations before starting the server
         await db.runMigrations();
 
+        // Auto-create admin user if no users exist (first start)
+        const { rows } = await db.query('SELECT COUNT(*) as count FROM users');
+        if (parseInt(rows[0].count) === 0) {
+            const { hashPassword } = require('./utils/auth');
+            const crypto = require('crypto');
+            const defaultPassword = 'admin';
+            const hash = await hashPassword(defaultPassword);
+            await db.query(
+                `INSERT INTO users (id, username, email, password_hash, name, role, is_active, must_change_password)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+                [crypto.randomUUID(), 'admin', '', hash, 'Administrator', 'admin', true, true]
+            );
+            logger.info('=== FIRST START: Admin user created ===', { component: 'setup' });
+            logger.info('Username: admin / Password: admin', { component: 'setup' });
+            logger.info('You will be asked to change the password on first login.', { component: 'setup' });
+        }
+
         app.listen(PORT, '0.0.0.0', () => {
             logger.info('Food Planner Backend started', { port: PORT, component: 'server' });
         });

--- a/backend/utils/auth.js
+++ b/backend/utils/auth.js
@@ -33,6 +33,20 @@ function validateEmail(email) {
 }
 
 /**
+ * Validate username format - pure function
+ * @param {string} username
+ * @returns {{ valid: boolean, error?: string }}
+ */
+function validateUsername(username) {
+    if (!username || typeof username !== 'string') return { valid: false, error: 'Username is required' };
+    const trimmed = username.trim();
+    if (trimmed.length < 3) return { valid: false, error: 'Username must be at least 3 characters' };
+    if (trimmed.length > 50) return { valid: false, error: 'Username must be at most 50 characters' };
+    if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) return { valid: false, error: 'Username may only contain letters, numbers, underscore and hyphen' };
+    return { valid: true };
+}
+
+/**
  * Validate password strength - pure function
  * @param {string} password
  * @returns {{ valid: boolean, error?: string }}
@@ -80,13 +94,14 @@ async function verifyPassword(password, hash) {
 
 /**
  * Create a JWT payload from a user object - pure function
- * @param {{ id: string, email: string, name?: string }} user
- * @returns {{ sub: string, email: string, name: string }}
+ * @param {{ id: string, username: string, email?: string, name?: string }} user
+ * @returns {{ sub: string, username: string, email: string, name: string, role: string }}
  */
 function createUserPayload(user) {
     return {
         sub: user.id,
-        email: user.email,
+        username: user.username,
+        email: user.email || '',
         name: user.name || '',
         role: user.role || 'user'
     };
@@ -203,6 +218,7 @@ function generateTempPassword() {
 
 module.exports = {
     validateEmail,
+    validateUsername,
     validatePassword,
     hashPassword,
     verifyPassword,

--- a/js/core/auth-modal.js
+++ b/js/core/auth-modal.js
@@ -23,7 +23,7 @@ export const AuthModal = {
                 <h2 class="ds-page-title mb-4">${isLogin ? 'Anmelden' : 'Registrieren'}</h2>
                 <form id="auth-modal-form" class="space-y-3">
                     ${!isLogin ? '<input id="auth-name" type="text" placeholder="Name (optional)" class="ds-input"/>' : ''}
-                    <input id="auth-email" type="email" placeholder="E-Mail" required class="ds-input"/>
+                    <input id="auth-username" type="text" placeholder="Benutzername" required class="ds-input" autocomplete="username"/>
                     <input id="auth-password" type="password" placeholder="Passwort" required minlength="8" class="ds-input"/>
                     <div id="auth-error" class="text-xs text-ds-danger hidden"></div>
                     <button type="submit" class="ds-btn ds-btn-primary w-full">${isLogin ? 'Anmelden' : 'Registrieren'}</button>
@@ -43,16 +43,16 @@ export const AuthModal = {
 
         overlay.querySelector('#auth-modal-form').addEventListener('submit', async (e) => {
             e.preventDefault();
-            const email = overlay.querySelector('#auth-email').value;
+            const username = overlay.querySelector('#auth-username').value;
             const password = overlay.querySelector('#auth-password').value;
             const errEl = overlay.querySelector('#auth-error');
             errEl.classList.add('hidden');
             try {
                 if (isLogin) {
-                    await Auth.login(email, password);
+                    await Auth.login(username, password);
                 } else {
                     const name = overlay.querySelector('#auth-name')?.value || '';
-                    await Auth.register(email, password, name);
+                    await Auth.register(username, password, name);
                 }
                 this.close();
                 if (this._onSuccess) this._onSuccess();
@@ -63,7 +63,7 @@ export const AuthModal = {
             }
         });
 
-        overlay.querySelector('#auth-email').focus();
+        overlay.querySelector('#auth-username').focus();
     },
 
     close() {

--- a/js/core/auth.js
+++ b/js/core/auth.js
@@ -101,12 +101,12 @@ export const Auth = {
         }
     },
 
-    async login(email, password) {
+    async login(username, password) {
         const res = await fetch('/auth/login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'same-origin',
-            body: JSON.stringify({ email, password })
+            body: JSON.stringify({ username, password })
         });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || 'Anmeldung fehlgeschlagen');
@@ -114,12 +114,12 @@ export const Auth = {
         return data.user;
     },
 
-    async register(email, password, name) {
+    async register(username, password, name) {
         const res = await fetch('/auth/register', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'same-origin',
-            body: JSON.stringify({ email, password, name })
+            body: JSON.stringify({ username, password, name })
         });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || 'Registrierung fehlgeschlagen');

--- a/js/views/admin-users.js
+++ b/js/views/admin-users.js
@@ -78,7 +78,7 @@ export const AdminUsersView = {
                     <thead class="bg-ds-bg-muted">
                         <tr>
                             <th class="admin-sort-col px-4 py-3 text-left font-medium text-ds-text-sec cursor-pointer hover:text-ds-accent" data-field="name">Name${sortIcon('name')}</th>
-                            <th class="admin-sort-col px-4 py-3 text-left font-medium text-ds-text-sec cursor-pointer hover:text-ds-accent" data-field="email">E-Mail${sortIcon('email')}</th>
+                            <th class="admin-sort-col px-4 py-3 text-left font-medium text-ds-text-sec cursor-pointer hover:text-ds-accent" data-field="username">Benutzername${sortIcon('username')}</th>
                             <th class="admin-sort-col px-4 py-3 text-left font-medium text-ds-text-sec cursor-pointer hover:text-ds-accent" data-field="role">Rolle${sortIcon('role')}</th>
                             <th class="admin-sort-col px-4 py-3 text-left font-medium text-ds-text-sec cursor-pointer hover:text-ds-accent" data-field="is_active">Status${sortIcon('is_active')}</th>
                             <th class="admin-sort-col px-4 py-3 text-left font-medium text-ds-text-sec cursor-pointer hover:text-ds-accent" data-field="created_at">Erstellt${sortIcon('created_at')}</th>
@@ -111,7 +111,7 @@ export const AdminUsersView = {
         return `
             <tr class="hover:bg-ds-bg-muted ${isSelf ? 'bg-ds-accent-bg/50' : ''}">
                 <td class="px-4 py-3 text-ds-text">${escapeHtml(user.name || '—')}${isSelf ? ' <span class="text-xs text-ds-accent">(Du)</span>' : ''}</td>
-                <td class="px-4 py-3 text-ds-text-body">${escapeHtml(user.email)}${mustChangeBadge}</td>
+                <td class="px-4 py-3 text-ds-text-body">${escapeHtml(user.username || '—')}${mustChangeBadge}</td>
                 <td class="px-4 py-3">${roleBadge}</td>
                 <td class="px-4 py-3">${statusBadge}</td>
                 <td class="px-4 py-3 text-ds-text-muted text-xs">${formatDate(user.created_at)}</td>
@@ -125,10 +125,10 @@ export const AdminUsersView = {
                             <button class="admin-toggle-status ds-badge cursor-pointer hover:opacity-80 transition-opacity ${user.is_active ? 'bg-ds-danger-bg text-ds-danger' : 'bg-ds-accent-bg text-ds-accent'}" data-id="${user.id}" data-active="${user.is_active}">
                                 ${user.is_active ? 'Deaktivieren' : 'Aktivieren'}
                             </button>
-                            <button class="admin-reset-pw ds-badge ds-badge-accent cursor-pointer hover:opacity-80 transition-opacity" data-id="${user.id}" data-email="${escapeHtml(user.email)}">
+                            <button class="admin-reset-pw ds-badge ds-badge-accent cursor-pointer hover:opacity-80 transition-opacity" data-id="${user.id}" data-username="${escapeHtml(user.username || '')}">
                                 Passwort
                             </button>
-                            <button class="admin-delete-user ds-badge cursor-pointer hover:opacity-80 transition-opacity bg-ds-danger-bg text-ds-danger" data-id="${user.id}" data-email="${escapeHtml(user.email)}">
+                            <button class="admin-delete-user ds-badge cursor-pointer hover:opacity-80 transition-opacity bg-ds-danger-bg text-ds-danger" data-id="${user.id}" data-username="${escapeHtml(user.username || '')}">
                                 Löschen
                             </button>
                         `}
@@ -145,7 +145,7 @@ export const AdminUsersView = {
                     <h3 class="ds-section-title mb-4">Neuen Benutzer anlegen</h3>
                     <p class="text-sm text-ds-text-muted mb-4">Es wird ein temporäres Passwort generiert. Der Benutzer muss es beim ersten Login ändern.</p>
                     <form id="admin-create-form" class="space-y-3">
-                        <input id="admin-create-email" type="email" placeholder="E-Mail-Adresse" required
+                        <input id="admin-create-username" type="text" placeholder="Benutzername" required
                             class="ds-input w-full px-3 py-2" />
                         <input id="admin-create-name" type="text" placeholder="Name (optional)"
                             class="ds-input w-full px-3 py-2" />
@@ -170,7 +170,7 @@ export const AdminUsersView = {
             <div id="admin-temppw-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50">
                 <div class="ds-card shadow-xl p-6 w-full max-w-sm mx-4">
                     <h3 class="ds-section-title mb-2">Temporäres Passwort</h3>
-                    <p id="admin-temppw-email" class="text-sm text-ds-text-muted mb-4"></p>
+                    <p id="admin-temppw-user" class="text-sm text-ds-text-muted mb-4"></p>
                     <div class="flex items-center gap-2 mb-4">
                         <code id="admin-temppw-value" class="flex-1 px-4 py-3 bg-ds-bg-subtle rounded-lg text-lg font-mono text-center text-ds-text tracking-wider select-all"></code>
                         <button id="admin-temppw-copy" class="ds-btn ds-btn-primary px-3 py-3" title="Kopieren">
@@ -218,17 +218,17 @@ export const AdminUsersView = {
 
     _showCreateModal() {
         const modal = document.getElementById('admin-create-modal');
-        document.getElementById('admin-create-email').value = '';
+        document.getElementById('admin-create-username').value = '';
         document.getElementById('admin-create-name').value = '';
         document.getElementById('admin-create-role').value = 'user';
         document.getElementById('admin-create-error').classList.add('hidden');
         modal.classList.remove('hidden');
-        document.getElementById('admin-create-email').focus();
+        document.getElementById('admin-create-username').focus();
     },
 
-    _showTempPassword(email, tempPassword) {
+    _showTempPassword(username, tempPassword) {
         const modal = document.getElementById('admin-temppw-modal');
-        document.getElementById('admin-temppw-email').textContent = email;
+        document.getElementById('admin-temppw-user').textContent = username;
         document.getElementById('admin-temppw-value').textContent = tempPassword;
         modal.classList.remove('hidden');
     },
@@ -238,14 +238,14 @@ export const AdminUsersView = {
         const errEl = document.getElementById('admin-create-error');
         errEl.classList.add('hidden');
 
-        const email = document.getElementById('admin-create-email').value.trim();
+        const username = document.getElementById('admin-create-username').value.trim();
         const name = document.getElementById('admin-create-name').value.trim();
         const role = document.getElementById('admin-create-role').value;
 
         try {
-            const data = await api.post('/admin/users', { email, name: name || undefined, role });
+            const data = await api.post('/admin/users', { username, name: name || undefined, role });
             document.getElementById('admin-create-modal').classList.add('hidden');
-            this._showTempPassword(email, data.tempPassword);
+            this._showTempPassword(username, data.tempPassword);
             await this._loadUsers();
         } catch (err) {
             errEl.textContent = err.message;
@@ -293,11 +293,11 @@ export const AdminUsersView = {
         // Reset password
         document.querySelectorAll('.admin-reset-pw').forEach(btn => {
             btn.addEventListener('click', async () => {
-                const email = btn.dataset.email;
-                if (!confirm(`Passwort für "${email}" wirklich zurücksetzen? Ein neues temporäres Passwort wird generiert.`)) return;
+                const username = btn.dataset.username;
+                if (!confirm(`Passwort für "${username}" wirklich zurücksetzen? Ein neues temporäres Passwort wird generiert.`)) return;
                 try {
                     const data = await api.put(`/admin/users/${btn.dataset.id}/reset-password`, {});
-                    this._showTempPassword(email, data.tempPassword);
+                    this._showTempPassword(username, data.tempPassword);
                     await this._loadUsers();
                 } catch (err) {
                     Toast.show(err.message, { type: 'error' });
@@ -308,8 +308,8 @@ export const AdminUsersView = {
         // Delete user
         document.querySelectorAll('.admin-delete-user').forEach(btn => {
             btn.addEventListener('click', async () => {
-                const email = btn.dataset.email;
-                if (!confirm(`Benutzer "${email}" wirklich endgültig löschen? Diese Aktion kann nicht rückgängig gemacht werden.`)) return;
+                const username = btn.dataset.username;
+                if (!confirm(`Benutzer "${username}" wirklich endgültig löschen? Diese Aktion kann nicht rückgängig gemacht werden.`)) return;
                 await this._apiCall(`/admin/users/${btn.dataset.id}`, 'DELETE');
             });
         });


### PR DESCRIPTION
## Summary
- Login/Register nutzen jetzt **Username** statt E-Mail
- Beim ersten Container-Start wird automatisch ein Admin-User angelegt:
  - Username: `admin`, Passwort: `admin`
  - `must_change_password: true` — Passwortaenderung wird beim ersten Login erzwungen
- E-Mail-Feld bleibt in DB (optional), wird aber nicht mehr fuer Login verwendet

## Aenderungen

### Backend
- **Migration** `012_auth_username.sql`: Username-Spalte, Unique-Index, E-Mail optional
- **Auth-Routes**: Login/Register/Me/Refresh auf Username umgestellt
- **Admin-Routes**: User-Verwaltung mit Username statt E-Mail
- **server.js**: Auto-Create Admin wenn DB leer (nach Migrations)
- **Zod-Schemas**: Validierung auf Username (3-50 Zeichen, alphanumerisch + _-)
- **Auth-Utils**: `validateUsername()` + `createUserPayload()` mit Username

### Frontend
- **Auth-Modal**: "Benutzername" statt "E-Mail" in Login/Register
- **Auth-Modul**: `login()`/`register()` senden Username
- **Admin-View**: Tabelle und Formulare auf Username umgestellt

### Tests
- 11 neue `validateUsername` Tests
- Aktualisierte `createUserPayload` Tests
- **244/244 Tests bestehen**

## Test plan
- [ ] Container starten, Admin-User in Logs pruefen
- [ ] Login mit admin/admin, Passwortaenderung testen
- [ ] Neuen User anlegen (Admin-Bereich)
- [ ] Login mit neuem User