### PR TITLE
fix: Login-Schema Username-Mindestlänge auf 3 angleichen

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,10 @@
 {
   "name": "food-planner-backend",
-  "version": "2.0.3",
+<<<<<<< HEAD
+  "version": "2.0.4",
+=======
+  "version": "2.0.4",
+>>>>>>> 00fa9c9 (chore: bump version to 2.0.4)
   "description": "Backend API for Food Planner",
   "main": "server.js",
   "scripts": {

--- a/backend/schemas/auth.js
+++ b/backend/schemas/auth.js
@@ -1,7 +1,7 @@
 const { z } = require('zod');
 
 const loginSchema = z.object({
-    username: z.string().min(1).max(50),
+    username: z.string().min(3).max(50),
     password: z.string().min(1).max(128),
 });
 


### PR DESCRIPTION
## Summary
- `loginSchema.username` von `min(1)` auf `min(3)` geändert, konsistent mit `registerSchema`

Closes #248

## Test plan
- [ ] Login mit Username < 3 Zeichen wird abgelehnt (400)
- [ ] Login mit Username >= 3 Zeichen funktioniert weiterhin