### PR TITLE
fix: Backend als non-root, CSP und HSTS Header ergänzen

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "food-planner-backend",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Backend API for Food Planner",
   "main": "server.js",
   "scripts": {

--- a/nginx.aio.conf
+++ b/nginx.aio.conf
@@ -19,6 +19,8 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; img-src 'self' data:; frame-ancestors 'none'" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         root /usr/share/nginx/html;
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -7,6 +7,7 @@ user=root
 [program:backend]
 command=node /app/backend/server.js
 directory=/app/backend
+user=node
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
## Summary
- Backend-Prozess in supervisord läuft jetzt als `node` User statt root
- Content-Security-Policy Header in nginx ergänzt (self + CDN für marked.js + Google Fonts)
- Strict-Transport-Security Header in nginx ergänzt (max-age 1 Jahr)

Closes #249, closes #250

## Test plan
- [ ] Container startet erfolgreich, Healthcheck grün
- [ ] Backend-Prozess läuft als `node` (prüfen mit `docker exec foodplanner ps aux`)
- [ ] Response-Header enthalten CSP und HSTS
- [ ] marked.js (CDN) und Google Fonts laden trotz CSP